### PR TITLE
WIP feat: generate pdf function

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
   "devDependencies": {
     "@types/ajv": "^1.0.0",
     "@types/chai": "^4.2.14",
+    "@types/jsdom": "^16.2.5",
     "@types/lodash.get": "^4.4.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/mjml": "^4.0.4",
     "@types/mocha": "^8.0.3",
     "@types/node": "14.0.27",
+    "@types/pdfmake": "^0.1.16",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
     "chai": "^4.2.0",
@@ -45,13 +47,16 @@
     "ajv": "^6.12.6",
     "axios": "^0.20.0",
     "handlebars": "^4.7.6",
+    "html-to-pdfmake": "^2.1.0",
+    "jsdom": "^16.4.0",
     "json-schema-to-typescript": "^9.1.1",
     "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "lodash.merge": "^4.6.2",
     "mjml": "^4.7.1",
-    "node-cache": "^5.1.2"
+    "node-cache": "^5.1.2",
+    "pdfmake": "^0.1.68"
   },
   "pre-commit": [
     "lint",

--- a/src/extract-emails.ts
+++ b/src/extract-emails.ts
@@ -53,6 +53,13 @@ function extractEmailsFromECoC(certificate: ECoCSchema): PartyEmail[] {
   if (!certificate.EcocData?.Data?.Parties) {
     return [];
   }
+  
+  const purchaseOrderNumber = certificate.EcocData?.BusinessReference?.StandardReferences.find(
+    (ref) => ref?.name === 'OrderNo'
+  )?.Value;
+  const purchaseOrderPosition = certificate.EcocData?.BusinessReference?.StandardReferences.find(
+    (ref) => ref?.name === 'OrderPos'
+  )?.Value;
 
   return certificate.EcocData.Data.Parties.map((party) => {
     const emailProp = party?.AdditionalPartyProperties?.find(
@@ -63,6 +70,8 @@ function extractEmailsFromECoC(certificate: ECoCSchema): PartyEmail[] {
           name: party.PartyName,
           role: party.PartyRole,
           emails: emailProp.Value,
+          purchaseOrderNumber,
+          purchaseOrderPosition,
         }
       : null;
   }).filter((partyEmail) => partyEmail !== null);

--- a/src/generate-pdf.ts
+++ b/src/generate-pdf.ts
@@ -1,0 +1,84 @@
+import merge from 'lodash.merge';
+import htmlToPdfmake from 'html-to-pdfmake';
+import jsdom from 'jsdom';
+import PdfPrinter from 'pdfmake';
+import pdfMake from 'pdfmake/build/pdfmake';
+import pdfFonts from 'pdfmake/build/vfs_fonts';
+import { loadExternalFile } from './utils';
+import { TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';
+
+export type GeneratePdfOptions = {
+  inputType?: 'html' | 'json';
+  outputType?: 'buffer' | 'stream';
+  templatePath?: string;
+  docDefinition?: TDocumentDefinitions;
+  fonts?: TFontDictionary;
+};
+
+const baseDocDefinition = (
+  pdfMakeContent: TDocumentDefinitions['content']
+): TDocumentDefinitions => ({
+  pageSize: 'A4',
+  pageMargins: [20, 20, 20, 40],
+  content: [pdfMakeContent],
+});
+
+export async function generatePdf(
+  certificateInput: string | object,
+  options: GeneratePdfOptions = { inputType: 'html', outputType: 'buffer' }
+): Promise<Buffer | PDFKit.PDFDocument> {
+  let rawCert: any;
+  if (typeof certificateInput === 'string') {
+    rawCert = (await loadExternalFile(certificateInput, 'json')) as any;
+  } else if (typeof certificateInput === 'object') {
+    rawCert = certificateInput;
+  } else {
+    throw new Error(`Invalid input type : ${typeof certificateInput}`);
+  }
+
+  const { JSDOM } = jsdom;
+  const dom = new JSDOM('');
+
+  let pdfMakeContent: TDocumentDefinitions['content'];
+  if (options.inputType === 'html') {
+    pdfMakeContent = htmlToPdfmake(rawCert, { window: dom.window });
+  } else if (options.inputType === 'json') {
+    // TODO: convert JSON certificate to pdfMake structure
+    pdfMakeContent = {} as TDocumentDefinitions['content'];
+  } else {
+    throw new Error('Invalid inputType');
+  }
+
+  const docDefinition: TDocumentDefinitions = options.docDefinition
+    ? merge(options.docDefinition, baseDocDefinition(pdfMakeContent))
+    : baseDocDefinition(pdfMakeContent);
+
+  // console.log('PDF generation', docDefinition);
+  let pdfDoc: PDFKit.PDFDocument;
+  if (options.fonts) {
+    const printer = new PdfPrinter(options.fonts);
+    pdfDoc = printer.createPdfKitDocument(docDefinition);
+  } else {
+    pdfMake.vfs = pdfFonts.pdfMake.vfs;
+    pdfDoc = pdfMake.createPdf(docDefinition).getStream();
+  }
+
+  if (options.outputType === 'stream') {
+    return pdfDoc;
+  } else if (options.outputType === 'buffer') {
+    return new Promise((resolve, reject) => {
+      let buffer: Buffer = Buffer.alloc(0);
+      pdfDoc.on('data', (data) => {
+        buffer = Buffer.concat([buffer, data], buffer.length + data.length);
+      });
+      pdfDoc.on('end', () => {
+        resolve(buffer);
+      });
+      pdfDoc.on('error', (error) => {
+        reject(error);
+      });
+    });
+  }
+
+  throw new Error('Invalid outputType');
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,15 +38,15 @@ export function writeFile(path: string, content: string) {
 
 export type ExternalFile = ReturnType<typeof loadExternalFile>;
 
-// TODO: add options as 3rd arg, with encoding and other stream options
+// TODO: add options as fourth arg, with encoding and other stream options ?
 export async function loadExternalFile(
   filePath: string,
   type: 'json' | 'text' | 'arraybuffer' | 'stream' = 'json',
   useCache: boolean = true
 ): Promise<object | string | Readable | undefined> {
   let result: object | string | Readable | undefined = useCache
-    ? undefined
-    : cache.get(filePath);
+    ? cache.get(filePath)
+    : undefined;
 
   if (result) {
     return result;

--- a/test/extract-emails.spec.ts
+++ b/test/extract-emails.spec.ts
@@ -33,6 +33,8 @@ describe('ExtractEmails', () => {
         name: 'VOESTALPINE BOHLER AEROSPACE GMBH & CO KG',
         role: 'Customer',
         emails: ['contact@s1seven.com'],
+        purchaseOrderNumber: undefined,
+        purchaseOrderPosition: undefined,
       },
     ];
     expect(emailsList).to.deep.equal(expectedResult);


### PR DESCRIPTION
Creating `generatePdf` function that can take an html path/Buffer or json certificate path/object as input.

If `options.inputType === 'html'` it will be parsed with [html-to-pdfmake](https://github.com/Aymkdn/html-to-pdfmake) 
else if `options.inputType === 'json'` it will be parsed with a custom function (needs to be created) 

Both cases should return a `TDocumentDefinitions['content']` object that will be used in `docDefinition.content`, to generate a PDF with [pdfmake](https://github.com/bpampuch/pdfmake).

`docDefinition` can be customized via `options.docDefinition` passed to `generatePdf` 2nd argument.
