### PR TITLE
WIP Build models

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains tools to validate certificate(s), generate TS interfaces from a specified schema and generate HTML string from a certificate.
 
-All the modules take as input a certificate path | url | object from which the `RefSchemaUrl` property will be resolved to fetch dependencies located `https://schemas.en10204.io/` such as schema reference, translations, templates ...
+All the modules take as input a certificate path | url | object from which the `RefSchemaUrl` property will be resolved to fetch dependencies located `https://schemas.en10204.io/<schemaType>/<version>/<filename>` such as schema reference, translations, templates ...
 
 ## Install
 
@@ -52,7 +52,33 @@ First argument is the certificate path to generate from.
 node ./examples/generate-html.js ./fixtures/EN10168/valid_en10168_test.json
 ```
 
+## Generate PDF
+
+TODO
+
+## Extract Emails
+
+TODO
+
+## Build Models
+
+The example uses the `CertificateModel` class in a function using `process.argv`.
+
+First argument is the schema type, and the second argument is the version of the schema that should be loaded to create a classe extending `CertificateModel`.
+
+```bash
+node ./examples/certificate-model.js en10168-schemas v0.0.2-2
+```
+
+## TODO
+
+Create tests for each minor release of [en10168-schemas] and [e-coc-schemas] using some examples from [en10168] and [dinspec9012] as fixtures.
+
 [ajv]: https://www.npmjs.com/package/ajv
 [json-schema-to-typescript]: https://www.npmjs.com/package/json-schema-to-typescript
 [handlebars]: https://www.npmjs.com/package/handlebars
 [mjml]: https://www.npmjs.com/package/mjml
+[en10168-schemas]: https://github.com/s1seven/EN10168-schemas
+[e-coc-schemas]: https://github.com/s1seven/E-CoC-schemas
+[en10168]: https://github.com/s1seven/EN10168
+[dinspec9012]: https://github.com/s1seven/DINSPEC9012

--- a/examples/certificate-model.js
+++ b/examples/certificate-model.js
@@ -1,0 +1,31 @@
+const { CertificateModel } = require('../dist/index');
+const validCertificate = requires('../fixtures/EN10168/valid_cert.json');
+
+(async function (argv) {
+  try {
+    const schemaType = argv[2] || 'v0.0.2-2';
+    const schemaVersion = argv[3] || 'en10168-schemas';
+
+    const CertModel = await CertificateModel.build({
+      schemaConfig: {
+        version: schemaVersion,
+        schemaType,
+      },
+    });
+
+    const cert = new CertModel(validCertificate);
+    cert.set({
+      RefSchemaUrl:
+        'https://schemas.en10204.io/en10168-schemas/v0.0.2-3/schema.json',
+    });
+
+    const RefSchemaUrl = cert.get('RefSchemaUrl');
+    console.log({ RefSchemaUrl });
+    const validation = cert.validate();
+    console.log({ isValid: validation.isValid });
+    const toJSON = cert.toJSON();
+    console.log('Certificate instance', toJSON);
+  } catch (error) {
+    console.error(error.message);
+  }
+})(process.argv);

--- a/package.json
+++ b/package.json
@@ -22,11 +22,15 @@
   "devDependencies": {
     "@types/ajv": "^1.0.0",
     "@types/chai": "^4.2.14",
+    "@types/lodash.clonedeepwith": "^4.5.6",
+    "@types/lodash.flatten": "^4.4.6",
     "@types/lodash.get": "^4.4.6",
+    "@types/lodash.groupby": "^4.6.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/mjml": "^4.0.4",
     "@types/mocha": "^8.0.3",
     "@types/node": "14.0.27",
+    "@types/semver-regex": "^3.1.0",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
     "chai": "^4.2.0",
@@ -39,19 +43,20 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
+    "@chialab/schema-model": "^1.3.4",
     "@restless/sanitizers": "^0.2.5",
-    "@types/lodash.flatten": "^4.4.6",
-    "@types/lodash.groupby": "^4.6.6",
     "ajv": "^6.12.6",
     "axios": "^0.20.0",
     "handlebars": "^4.7.6",
     "json-schema-to-typescript": "^9.1.1",
+    "lodash.clonedeepwith": "^4.5.0",
     "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "lodash.merge": "^4.6.2",
     "mjml": "^4.7.1",
-    "node-cache": "^5.1.2"
+    "node-cache": "^5.1.2",
+    "semver-regex": "^3.1.1"
   },
   "pre-commit": [
     "lint",

--- a/src/certificate-model.ts
+++ b/src/certificate-model.ts
@@ -1,0 +1,310 @@
+import Ajv from 'ajv';
+import { EventEmitter } from 'events';
+import { JSONSchema } from 'json-schema-to-typescript';
+import cloneDeepWith from 'lodash.clonedeepwith';
+import merge from 'lodash.merge';
+import { URL } from 'url';
+import { extractEmails, PartyEmail } from './extract-emails';
+import { generateHtml, GenerateHtmlOptions } from './generate-html';
+import { SchemaTypes } from './types';
+import {
+  getSemanticVersion,
+  loadExternalFile,
+  formatValidationErrors,
+  castCertificate,
+} from './utils';
+
+export type SchemaConfig = {
+  schemaType: SchemaTypes;
+  version: string;
+  baseUrl: string;
+};
+
+export type BuildCertificateModelOptions = {
+  schema?: JSONSchema;
+  schemaConfig: Partial<SchemaConfig>;
+};
+
+export type KVCertificateModelOptions = {
+  validate: boolean;
+  internal: boolean;
+};
+
+export type CertificateInstance = ReturnType<typeof castCertificate>;
+
+const defaultBuildCertificateOptions: SchemaConfig = {
+  schemaType: 'en10168-schemas',
+  version: 'v0.0.2',
+  baseUrl: 'https://schemas.en10204.io/',
+};
+
+const defaultKVSchemaOptions: KVCertificateModelOptions = {
+  validate: true,
+  internal: false,
+};
+
+function getRefSchemaUrl(opts: SchemaConfig): URL {
+  const { baseUrl, schemaType, version } = opts;
+  const refSchemaUrl = new URL(baseUrl);
+  refSchemaUrl.pathname = `${schemaType.toLowerCase()}/v${version}/schema.json`;
+  return refSchemaUrl;
+}
+
+async function loadSchema(options: SchemaConfig): Promise<JSONSchema> {
+  const opts = {
+    ...defaultBuildCertificateOptions,
+    ...(options || {}),
+  } as SchemaConfig;
+  const url = getRefSchemaUrl(opts).href;
+  return (await loadExternalFile(url, 'json')) as JSONSchema;
+}
+
+async function getSchema(
+  options: Partial<BuildCertificateModelOptions>
+): Promise<{ schema: JSONSchema; schemaConfig: SchemaConfig }> {
+  let schema: JSONSchema;
+  let schemaConfig: SchemaConfig;
+
+  if (options.schemaConfig) {
+    schemaConfig = {
+      ...defaultBuildCertificateOptions,
+      ...(options.schemaConfig || {}),
+    } as SchemaConfig;
+    schemaConfig.version = getSemanticVersion(schemaConfig.version);
+    schema = await loadSchema(schemaConfig);
+  } else if (options.schema) {
+    schema = options.schema;
+    const refSchemaUrl = new URL(schema.$id);
+    const baseUrl = refSchemaUrl.origin;
+    const [, schemaType, version] = refSchemaUrl.pathname
+      .split('/')
+      .map((val, index) => {
+        if (index === 2) {
+          return getSemanticVersion(val);
+        }
+        return val;
+      }) as [any, SchemaTypes, string];
+    schemaConfig = { baseUrl, schemaType, version };
+  } else {
+    throw new Error('Invalid options');
+  }
+
+  return { schema, schemaConfig };
+}
+
+function getSymbol(name: string) {
+  if (!getSymbol.cache[name]) {
+    getSymbol.cache[name] =
+      typeof Symbol !== 'undefined' ? Symbol(name) : `__${name}`;
+  }
+  return getSymbol.cache[name];
+}
+
+getSymbol.cache = {};
+
+function get(scope: CertificateModel, key: string, internal?: boolean) {
+  if (internal) {
+    key = getSymbol(key);
+  }
+  return scope[key];
+}
+
+function set<T = any>(
+  scope: CertificateModel,
+  data: object | T,
+  internal?: boolean
+) {
+  Object.keys(data).forEach((key) => {
+    const ok = key;
+    if (internal) {
+      key = getSymbol(key);
+    }
+    if (scope[key] !== data[ok]) {
+      scope[key] = data[ok];
+    }
+  });
+}
+
+function getProperties(schema: any, validator?: Ajv.Ajv) {
+  const root = !validator;
+  if (root || !validator) {
+    const ajv = new Ajv();
+    validator = ajv.addSchema(schema, '');
+  }
+  if (schema.definitions) {
+    for (const key in schema.definitions) {
+      validator.addSchema(schema.definitions[key], `#/definitions/${key}`);
+    }
+  }
+  if (schema.$ref) {
+    schema = validator.getSchema(schema.$ref);
+  }
+  if (schema.properties) {
+    return cloneDeepWith(schema.properties);
+  }
+  let res = {};
+  const defs = schema['anyOf'] || schema['allOf'] || (root && schema['oneOf']);
+  if (defs) {
+    defs.forEach((def) => {
+      res = merge(res, getProperties(def, validator));
+    });
+  }
+  return res;
+}
+
+export class CertificateModel<T = any> extends EventEmitter {
+  static symbols: any;
+
+  static merge(obj1: object, obj2: object) {
+    return merge(obj1, obj2);
+  }
+
+  static clone(
+    obj1: object,
+    customizer?: (value: any, key?: string | number) => object // eslint-disable-line no-unused-vars
+  ) {
+    return typeof customizer === 'function'
+      ? cloneDeepWith(obj1, customizer)
+      : cloneDeepWith(obj1);
+  }
+
+  static cast(data: object): CertificateInstance {
+    return castCertificate(data);
+  }
+
+  static async build(
+    options: Partial<BuildCertificateModelOptions>
+  ): Promise<typeof CertificateModel> {
+    const { schema, schemaConfig } = await getSchema(options);
+    return class CertificateModel1<R = any> extends CertificateModel<R> {
+      get schema() {
+        return schema;
+      }
+      get schemaConfig() {
+        return schemaConfig;
+      }
+    };
+  }
+
+  static async buildInstance(
+    options: Partial<BuildCertificateModelOptions>,
+    data: any
+  ): Promise<CertificateModel<CertificateInstance>> {
+    const NewClass = await CertificateModel.build(options);
+    const certificate = CertificateModel.cast(data);
+    return new NewClass<CertificateInstance>(certificate);
+  }
+
+  constructor(data?: any, options?: object) {
+    super();
+    this.setListeners();
+    if (data) {
+      this.set(data, options || {});
+    }
+    this.emit('ready');
+  }
+
+  get schema(): JSONSchema {
+    throw new Error('Missing schema');
+  }
+
+  get schemaConfig(): SchemaConfig {
+    throw new Error('Missing schema config');
+  }
+
+  get schemaProperties() {
+    return getProperties(this.schema);
+  }
+
+  setListeners() {
+    this.on('generate-html:start', (options) => this.generateHtml(options));
+    this.on('generate-pdf:start', (options) => this.generatePdf(options));
+    this.on('error', (error) => {
+      console.error('CertificateModel', error.message || 'Unknown error');
+    });
+  }
+
+  get(name: string, options?: KVCertificateModelOptions) {
+    const opts = merge(defaultKVSchemaOptions, options || {});
+    return get(this, name, opts.internal);
+  }
+
+  set(
+    data: string | object | T,
+    value?: any | KVCertificateModelOptions,
+    options?: KVCertificateModelOptions
+  ) {
+    if (typeof data === 'string') {
+      return this.set(
+        {
+          [data]: value,
+        },
+        options
+      );
+    }
+    data = data || {};
+    const opts = merge(
+      defaultKVSchemaOptions,
+      value || {}
+    ) as KVCertificateModelOptions;
+
+    if (!opts.internal && opts.validate) {
+      const dataToValidate = merge(this.toJSON(true), data);
+      const res = this.validate(dataToValidate);
+      if (!res.valid) {
+        if (res.errors) {
+          const errors = formatValidationErrors(res.errors);
+          this.emit('error', new Error(JSON.stringify(errors, null, 2)));
+          throw new Error(JSON.stringify(errors, null, 2));
+        }
+        this.emit('error', new Error('Validation failed'));
+        throw new Error('Validation failed');
+      }
+    }
+    set<T>(this, data, opts.internal);
+  }
+
+  validate(
+    data?: T
+  ): { valid: boolean; errors: Ajv.ErrorObject[] | null | undefined } {
+    data = data || this.toJSON(true);
+    const schema = this.schema;
+    const ajv = new Ajv();
+    const valid = ajv.validate(schema, data) as boolean;
+    return { valid, errors: ajv.errors };
+  }
+
+  toJSON(stripUndefined?: boolean): T {
+    const keys = Object.keys(this.schemaProperties);
+    const res = keys.reduce((acc, key) => {
+      const val = this.get(key);
+      if (!stripUndefined || val !== undefined) {
+        acc[key] = val;
+      }
+      return acc;
+    }, {} as T);
+
+    return cloneDeepWith(res, (value) => {
+      if (value instanceof CertificateModel) {
+        return value.toJSON(stripUndefined);
+      }
+      return value;
+    });
+  }
+
+  async generateHtml(options?: GenerateHtmlOptions): Promise<string> {
+    const result = await generateHtml(this, options);
+    this.emit('generate-html:end', result);
+    return result;
+  }
+
+  async generatePdf(options: any): Promise<any> {
+    const result = Promise.resolve(options);
+    this.emit('generate-pdf:end', result);
+    return result;
+  }
+
+  async getEmails(): Promise<PartyEmail[] | null> {
+    return extractEmails(this);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-export { extractEmails } from './extract-emails';
+export { extractEmails, PartyEmail } from './extract-emails';
 export { generateHtml, GenerateHtmlOptions } from './generate-html';
 export { generate, GenerateOptions } from './generate-interfaces';
-export { validate, ValidationError, ValidateOptions } from './validate-schemas';
+export { validate, ValidateOptions } from './validate-schemas';
+export * from './types';
 export { loadExternalFile } from './utils';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+export {
+  CertificateModel,
+  BuildCertificateModelOptions,
+  KVCertificateModelOptions,
+} from './certificate-model';
 export { extractEmails, PartyEmail } from './extract-emails';
 export { generateHtml, GenerateHtmlOptions } from './generate-html';
 export { generate, GenerateOptions } from './generate-interfaces';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,11 @@
+export interface ValidationError {
+  root: string;
+  path: string;
+  keyword: string;
+  schemaPath: string;
+  expected: string;
+}
+
 export interface BaseCertificateSchema {
   RefSchemaUrl: string;
   [key: string]: any;
@@ -21,3 +29,5 @@ export interface ECoCSchema extends BaseCertificateSchema {
   URL: string;
   EcocData: any;
 }
+
+export type SchemaTypes = 'en10168-schemas' | 'e-coc-schemas';

--- a/test/certificate-model.spec.ts
+++ b/test/certificate-model.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+import { JSONSchema } from 'json-schema-to-typescript';
+import { EN10168Schema, loadExternalFile } from '../src';
+import { CertificateModel } from '../src/certificate-model';
+import validEn10168Certificate from '../fixtures/EN10168/valid_cert.json';
+import invalidEN10168Certificate from '../fixtures/EN10168/invalid_cert.json';
+import invalidECoCCertificate from '../fixtures/E-CoC/valid_cert.json';
+
+describe('BuilModel', function () {
+  this.timeout(4000);
+
+  it('should build and validate instance using schemaConfig EN10168 v0.0.2-2', async () => {
+    const CertModel = await CertificateModel.build({
+      schemaConfig: {
+        version: 'v0.0.2-2',
+        schemaType: 'en10168-schemas',
+      },
+    });
+
+    const cert = new CertModel<EN10168Schema>(validEn10168Certificate);
+
+    const validation = cert.validate();
+    const toJSON = cert.toJSON();
+    expect(JSON.stringify(toJSON, null, 2)).to.be.equal(
+      JSON.stringify(validEn10168Certificate, null, 2)
+    );
+    expect(validation.valid).to.be.equal(true);
+  });
+
+  it('should build and validate instance using schema EN10168 v0.0.2-2', async () => {
+    const schema = (await loadExternalFile(
+      'https://schemas.en10204.io/en10168-schemas/v0.0.2-2/schema.json',
+      'json'
+    )) as JSONSchema;
+
+    const cert = await CertificateModel.buildInstance(
+      { schema },
+      validEn10168Certificate
+    );
+
+    const validation = cert.validate();
+    const toJSON = cert.toJSON();
+    expect(JSON.stringify(toJSON, null, 2)).to.be.equal(
+      JSON.stringify(validEn10168Certificate, null, 2)
+    );
+    expect(validation.valid).to.be.equal(true);
+  });
+
+  it('should not build invalid instance using schemaConfig EN10168 v0.0.2-2', async () => {
+    const CertModel = await CertificateModel.build({
+      schemaConfig: {
+        version: 'v0.0.2-2',
+        schemaType: 'en10168-schemas',
+      },
+    });
+
+    expect(() => {
+      new CertModel<EN10168Schema>(invalidEN10168Certificate);
+    }).to.throw(
+      JSON.stringify(
+        [
+          {
+            root: '',
+            path: '.Certificate.ProductDescription.B02',
+            keyword: 'type',
+            schemaPath: '#/properties/B02/type',
+            expected: 'should be object',
+          },
+        ],
+        null,
+        2
+      )
+    );
+  });
+
+  // TODO: fix $ref resolution for https://e-coc.org/schema/v1.0.0/MaterialCertification.json#/definitions/MaterialTest
+  it.skip('should build model using schema config E-CoC v0.0.2', async () => {
+    const CertModel = await CertificateModel.build({
+      schemaConfig: {
+        version: 'v0.0.2-0',
+        schemaType: 'e-coc-schemas',
+      },
+    });
+
+    const cert = new CertModel<EN10168Schema>(invalidECoCCertificate);
+
+    const validation = cert.validate();
+    const toJSON = cert.toJSON();
+    expect(JSON.stringify(toJSON, null, 2)).to.be.equal(
+      JSON.stringify(invalidECoCCertificate, null, 2)
+    );
+    expect(validation.valid).to.be.equal(true);
+  });
+});

--- a/test/extract-emails.spec.ts
+++ b/test/extract-emails.spec.ts
@@ -4,7 +4,9 @@ import { extractEmails } from '../src/extract-emails';
 const en10168CertificatePath = `${__dirname}/../fixtures/EN10168/valid_cert.json`;
 const eCoCCertificatePath = `${__dirname}/../fixtures/E-CoC/valid_cert.json`;
 
-describe('ExtractEmails', () => {
+describe('ExtractEmails', function () {
+  this.timeout(4000);
+
   it('should extract emails from EN10168 certificate', async () => {
     const emailsList = await extractEmails(en10168CertificatePath);
     const expectedResult = [

--- a/test/generate-html.spec.ts
+++ b/test/generate-html.spec.ts
@@ -4,7 +4,9 @@ import { generateHtml } from '../src/generate-html';
 
 const certificatePath = `${__dirname}/../fixtures/EN10168/valid_cert.json`;
 
-describe('GenerateHTML', () => {
+describe('GenerateHTML', function () {
+  this.timeout(4000);
+
   const expectedHtmlFromHbs = readFileSync(
     `${__dirname}/../fixtures/EN10168/template_hbs.html`,
     'utf-8'

--- a/test/generate-interfaces.spec.ts
+++ b/test/generate-interfaces.spec.ts
@@ -5,7 +5,9 @@ import { generate } from '../src/generate-interfaces';
 
 const schemaPath = `https://schemas.en10204.io/en10168-schemas/v0.0.2-2/schema.json`;
 
-describe('GenerateInterfaces', () => {
+describe('GenerateInterfaces', function () {
+  this.timeout(4000);
+
   const certificate = readFileSync(
     `${__dirname}/../fixtures/EN10168/certificate.ts`,
     'utf-8'
@@ -22,7 +24,7 @@ describe('GenerateInterfaces', () => {
       useTabs: false,
     },
   };
-  
+
   it('should generate TS interfaces and types certificate using external schema path (url)', async () => {
     const interfaces = await generate(schemaPath, null, generateOptions);
     expect(interfaces).to.be.equal(certificate);

--- a/test/validate-schemas.spec.ts
+++ b/test/validate-schemas.spec.ts
@@ -2,7 +2,9 @@ import { expect } from 'chai';
 import { readFile } from '../src/utils';
 import { validate } from '../src/validate-schemas';
 
-describe('ValidateSchema', () => {
+describe('ValidateSchema', function () {
+  this.timeout(4000);
+
   describe('EN10168 types', () => {
     const validCertificatePath = `${__dirname}/../fixtures/EN10168/valid_cert.json`;
     const invalidCertificatePath = `${__dirname}/../fixtures/EN10168/invalid_cert.json`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,14 +13,12 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "typeRoots": [
-      "node_modules/@types",
-      "../node_modules/@types"
-    ],
-    "types": ["node", "mocha"]
+    "typeRoots": ["node_modules/@types", "../node_modules/@types"],
+    "types": ["node", "mocha"],
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true
   },
-  "include": [
-    "src",
-    "test"
-  ]
+  "include": ["src", "test"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Add a `CertificateModel` class that allows to generate certificateModel instance from a schema (config, refSchemaUrl or plain object).
Wrap functions from schema-tools (`generateHTML`, `extractEmails`, ... ) and add setter/getter that will do validation under the hood.