### PR TITLE
Extract extra E-CoC info

### DIFF
--- a/src/extract-emails.ts
+++ b/src/extract-emails.ts
@@ -53,6 +53,13 @@ function extractEmailsFromECoC(certificate: ECoCSchema): PartyEmail[] {
   if (!certificate.EcocData?.Data?.Parties) {
     return [];
   }
+  
+  const purchaseOrderNumber = certificate.EcocData?.BusinessReference?.StandardReferences.find(
+    (ref) => ref?.name === 'OrderNo'
+  )?.Value;
+  const purchaseOrderPosition = certificate.EcocData?.BusinessReference?.StandardReferences.find(
+    (ref) => ref?.name === 'OrderPos'
+  )?.Value;
 
   return certificate.EcocData.Data.Parties.map((party) => {
     const emailProp = party?.AdditionalPartyProperties?.find(
@@ -63,6 +70,8 @@ function extractEmailsFromECoC(certificate: ECoCSchema): PartyEmail[] {
           name: party.PartyName,
           role: party.PartyRole,
           emails: emailProp.Value,
+          purchaseOrderNumber,
+          purchaseOrderPosition,
         }
       : null;
   }).filter((partyEmail) => partyEmail !== null);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,15 +38,15 @@ export function writeFile(path: string, content: string) {
 
 export type ExternalFile = ReturnType<typeof loadExternalFile>;
 
-// TODO: add options as 3rd arg, with encoding and other stream options
+// TODO: add options as fourth arg, with encoding and other stream options ?
 export async function loadExternalFile(
   filePath: string,
   type: 'json' | 'text' | 'arraybuffer' | 'stream' = 'json',
   useCache: boolean = true
 ): Promise<object | string | Readable | undefined> {
   let result: object | string | Readable | undefined = useCache
-    ? undefined
-    : cache.get(filePath);
+    ? cache.get(filePath)
+    : undefined;
 
   if (result) {
     return result;

--- a/test/extract-emails.spec.ts
+++ b/test/extract-emails.spec.ts
@@ -33,6 +33,8 @@ describe('ExtractEmails', () => {
         name: 'VOESTALPINE BOHLER AEROSPACE GMBH & CO KG',
         role: 'Customer',
         emails: ['contact@s1seven.com'],
+        purchaseOrderNumber: undefined,
+        purchaseOrderPosition: undefined,
       },
     ];
     expect(emailsList).to.deep.equal(expectedResult);


### PR DESCRIPTION
- Add  `purchaseOrderNumber`, `purchaseOrderPosition` for E-Coc emails extraction

- Fix `useCache` condition in`loadExternalFile`