### PR TITLE
feat(versioning): allow passing `extraTranslations`

### DIFF
--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@s1seven/schema-tools-generate-html": "^0.2.0",
     "@s1seven/schema-tools-generate-pdf": "^0.0.20",
+    "@s1seven/schema-tools-types": "^0.3.0",
     "@s1seven/schema-tools-utils": "^0.1.0",
     "glob": "^7.2.0",
     "lodash.get": "^4.4.2",

--- a/packages/versioning/test/repository.spec.ts
+++ b/packages/versioning/test/repository.spec.ts
@@ -10,6 +10,7 @@ describe('Versioning', function () {
   const schemaName = 'schema.json';
   const defaultSchemaFilePaths: SchemaFileProperties[] = [{ filePath: '', properties: [{ value: '', path: '' }] }];
   const translations = { EN: {} };
+  const extraTranslations = { CAMPUS: { EN: {} } };
   const pattern = `${__dirname}/certificate-*`;
   const fixtures = {
     'certificate-1.json': { RefSchemaUrl: '' },
@@ -51,13 +52,20 @@ describe('Versioning', function () {
 
   it('should update HTML certificate fixtures', async () => {
     const templatePath = 'test.hbs';
-    const instance = new SchemaRepositoryVersion(serverUrl, defaultSchemaFilePaths, version, translations);
+    const instance = new SchemaRepositoryVersion(
+      serverUrl,
+      defaultSchemaFilePaths,
+      version,
+      translations,
+      extraTranslations,
+    );
     await instance.updateHtmlFixturesVersion(`${pattern}.json`, templatePath);
     expect(SchemaRepositoryVersion.generateHtmlCertificate).toBeCalledTimes(2);
     expect(SchemaRepositoryVersion.generateHtmlCertificate).toBeCalledWith(
       expect.stringContaining('certificate'),
       templatePath,
       translations,
+      extraTranslations,
       {},
     );
   });

--- a/packages/versioning/test/repository.spec.ts
+++ b/packages/versioning/test/repository.spec.ts
@@ -36,7 +36,7 @@ describe('Versioning', function () {
   });
 
   it('should update get RefSchemaUrl from parameters', () => {
-    const instance = new SchemaRepositoryVersion(serverUrl, defaultSchemaFilePaths, version, {}, schemaName);
+    const instance = new SchemaRepositoryVersion(serverUrl, defaultSchemaFilePaths, version, {}, null, schemaName);
     const RefSchemaUrl = instance.buildRefSchemaUrl();
     expect(RefSchemaUrl).toBe(`${serverUrl}/${version}/${schemaName}`);
   });


### PR DESCRIPTION
# Description

In `versioning`, allow to use `extraTranslations` for HTML generator 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
