### PR TITLE
fix: add localization for Value, Minimum and Maximum in inspections for generatePdf

### DIFF
--- a/packages/generate-coa-pdf-template/src/generateContent.ts
+++ b/packages/generate-coa-pdf-template/src/generateContent.ts
@@ -262,7 +262,11 @@ export function createProductDescription(product: Product, i18n: I18N): [Content
   ];
 }
 
-function createInspection(inspection: Inspection, i18n: I18N, PropertiesStandard?: ExternalStandardsEnum): TableCell[] {
+export function createInspection(
+  inspection: Inspection,
+  i18n: I18N,
+  PropertiesStandard?: ExternalStandardsEnum,
+): TableCell[] {
   const textFields: { name: string; format?: 'Number' }[] = [
     { name: 'Property' },
     { name: 'Method' },

--- a/packages/generate-coa-pdf-template/src/generateContent.ts
+++ b/packages/generate-coa-pdf-template/src/generateContent.ts
@@ -274,7 +274,8 @@ function createInspection(inspection: Inspection, i18n: I18N, PropertiesStandard
   ];
 
   return textFields.map((field) => {
-    const { name } = field;
+    const { name, format } = field;
+
     if (name === 'Property' || name === 'TestConditions') {
       return {
         text: computeTextStyle(
@@ -284,7 +285,15 @@ function createInspection(inspection: Inspection, i18n: I18N, PropertiesStandard
         ),
         style: 'caption',
       };
+    } else if (format === 'Number' && !Number.isNaN(Number(inspection[name]))) {
+      const localizedNumber = localizeNumber(inspection[name], i18n.languages);
+
+      return {
+        text: computeTextStyle(localizedNumber, field.format, i18n.languages),
+        style: 'caption',
+      };
     }
+
     return { text: computeTextStyle(inspection[name], field.format, i18n.languages), style: 'caption' };
   });
 }

--- a/packages/generate-coa-pdf-template/src/generateContent.ts
+++ b/packages/generate-coa-pdf-template/src/generateContent.ts
@@ -278,7 +278,7 @@ export function createInspection(
   ];
 
   return textFields.map((field) => {
-    const { name, format } = field;
+    const { name } = field;
 
     if (name === 'Property' || name === 'TestConditions') {
       return {
@@ -287,13 +287,6 @@ export function createInspection(
           field.format,
           i18n.languages,
         ),
-        style: 'caption',
-      };
-    } else if (format === 'Number' && !Number.isNaN(Number(inspection[name]))) {
-      const localizedNumber = localizeNumber(inspection[name], i18n.languages);
-
-      return {
-        text: computeTextStyle(localizedNumber, field.format, i18n.languages),
         style: 'caption',
       };
     }

--- a/packages/generate-coa-pdf-template/test/builders.spec.ts
+++ b/packages/generate-coa-pdf-template/test/builders.spec.ts
@@ -8,6 +8,7 @@ import {
   createContacts,
   createGeneralInfo,
   createHeader,
+  createInspection,
   createProductDescription,
   createReceivers,
 } from '../src/generateContent';
@@ -156,6 +157,27 @@ describe('Rendering', () => {
       expect.objectContaining({ text: i18n.translate('AdditionalInformation', 'Certificate') }),
     );
     expect(tableBody[4][0]).toEqual(expect.objectContaining({ text: AdditionalInformation.join('\n') }));
+  });
+
+  it('createInspection() - should correctly localize inspections', () => {
+    const i18n = getI18N(translations, ['DE', 'EN']);
+    const analysis = {
+      PropertyId: '1038',
+      Property: 'MFR',
+      Method: 'DIN EN ISO 1133',
+      Unit: 'g/10m_',
+      Value: 31.5,
+      ValueType: 'number',
+      Minimum: '15.1',
+      Maximum: '35.4',
+      TestConditions: 'According customer specification',
+    };
+    // Ensures that localization works irrespective of whether the value is a number or string
+    const inspection = createInspection(analysis as any, i18n);
+
+    expect(inspection[3]).toEqual(expect.objectContaining({ text: '31,5', style: 'caption' }));
+    expect(inspection[4]).toEqual(expect.objectContaining({ text: '15,1', style: 'caption' }));
+    expect(inspection[5]).toEqual(expect.objectContaining({ text: '35,4', style: 'caption' }));
   });
 
   it('createContacts() - should correctly render contact details', () => {

--- a/packages/generate-coa-pdf-template/test/builders.spec.ts
+++ b/packages/generate-coa-pdf-template/test/builders.spec.ts
@@ -160,7 +160,6 @@ describe('Rendering', () => {
   });
 
   it('createInspection() - should correctly localize inspections', () => {
-    const i18n = getI18N(translations, ['DE', 'EN']);
     const analysis = {
       PropertyId: '1038',
       Property: 'MFR',
@@ -172,12 +171,32 @@ describe('Rendering', () => {
       Maximum: '35.4',
       TestConditions: 'According customer specification',
     };
-    // Ensures that localization works irrespective of whether the value is a number or string
-    const inspection = createInspection(analysis as any, i18n);
 
+    const i18n = getI18N(translations, ['DE', 'EN']);
+    const inspection = createInspection(analysis as any, i18n);
     expect(inspection[3]).toEqual(expect.objectContaining({ text: '31,5', style: 'caption' }));
     expect(inspection[4]).toEqual(expect.objectContaining({ text: '15,1', style: 'caption' }));
     expect(inspection[5]).toEqual(expect.objectContaining({ text: '35,4', style: 'caption' }));
+
+    const i18n2 = getI18N(translations, ['EN', 'DE']);
+    const inspection2 = createInspection(analysis as any, i18n2);
+    expect(inspection2[3]).toEqual(expect.objectContaining({ text: '31.5', style: 'caption' }));
+    expect(inspection2[4]).toEqual(expect.objectContaining({ text: '15.1', style: 'caption' }));
+    expect(inspection2[5]).toEqual(expect.objectContaining({ text: '35.4', style: 'caption' }));
+  });
+
+  it('createInspection() - if Value is not a number, it should not localize it', () => {
+    const analysis = {
+      PropertyId: '239',
+      Property: 'Type of failure',
+      Method: 'ISO 179/1eU',
+      Value: 'C',
+      ValueType: 'string',
+    };
+
+    const i18n = getI18N(translations, ['DE', 'EN']);
+    const inspection = createInspection(analysis as any, i18n);
+    expect(inspection[3]).toEqual(expect.objectContaining({ text: 'C', style: 'caption' }));
   });
 
   it('createContacts() - should correctly render contact details', () => {

--- a/packages/generate-pdf-template-helpers/src/helpers.ts
+++ b/packages/generate-pdf-template-helpers/src/helpers.ts
@@ -33,6 +33,8 @@ export function computeTextStyle(
     return value.join(', ');
   } else if (format === 'Number' && typeof value === 'number') {
     return localizeNumber(value, locales);
+  } else if (format === 'Number' && typeof value === 'string' && !Number.isNaN(Number(value))) {
+    return localizeNumber(value, locales);
   }
   return value;
 }


### PR DESCRIPTION
# Description

Inspection values were not localizing correctly for the `Value`, `Minimum`, and `Maximum` properties if the type was a `string` instead of a `number`. This is due to a check in `localizeNumber` that checks if the value is of type `number`, otherwise returning the original value.

```TypeScript
else if (format === 'Number' && typeof value === 'number') {
    return localizeNumber(value, locales);
  }
```

My code localizes the number before it is passed to `computeTextStyle`, ensuring that it is correctly localized even if it is a `string`.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Reference related issues using keywords supported by Github as described [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

Example:
Fixes #(issue number)
-->

Fixes #143 
Fixes thematerials-network/CoA-schemas#46

Before:
![image](https://user-images.githubusercontent.com/21305201/168285199-32652b15-0731-48fa-bd45-24116056e3fe.png)


After:
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/21305201/168284913-199f887c-f3fa-416f-a1ea-e606092d5512.png">
As you can see in the screenshot, the values for `Value`, `Minimum` and `Maximum` are now correctly localized (they contain commas instead of dots).

## Type of change

<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
