### PR TITLE
ci: replace set-output in github workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -93,15 +93,15 @@ jobs:
           path: ./coverage
           retention-days: 2
 
-      # - name: Extract branch name
-      #   id: extract-branch
-      #   shell: bash
-      #   run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-
       - name: Extract branch name
         id: extract-branch
         shell: bash
-        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+
+      # - name: Extract branch name
+      #   id: extract-branch
+      #   shell: bash
+      #   run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
 
       - name: Print output
         run: echo "${{ steps.extract-branch.outputs.branch }}"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -96,7 +96,11 @@ jobs:
       - name: Extract branch name
         id: extract-branch
         shell: bash
-        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+        # run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+
+      - name: Use prior output
+        run: echo "${{ steps.extract-branch.outputs.branch }}"
 
       - name: Add, commit and push changes to dist/generateContents.js
         if: steps.extract-branch.outputs.branch != 'main'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -96,15 +96,7 @@ jobs:
       - name: Extract branch name
         id: extract-branch
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-
-      # - name: Extract branch name
-      #   id: extract-branch
-      #   shell: bash
-      #   run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-
-      - name: Print output
-        run: echo "${{ steps.extract-branch.outputs.branch }}"
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
 
       - name: Add, commit and push changes to dist/generateContents.js
         if: steps.extract-branch.outputs.branch != 'main'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -93,10 +93,18 @@ jobs:
           path: ./coverage
           retention-days: 2
 
+      # - name: Extract branch name
+      #   id: extract-branch
+      #   shell: bash
+      #   run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+
       - name: Extract branch name
         id: extract-branch
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+
+      - name: Print output
+        run: echo "${{ steps.extract-branch.outputs.branch }}"
 
       - name: Add, commit and push changes to dist/generateContents.js
         if: steps.extract-branch.outputs.branch != 'main'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -96,11 +96,7 @@ jobs:
       - name: Extract branch name
         id: extract-branch
         shell: bash
-        # run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-
-      - name: Use prior output
-        run: echo "${{ steps.extract-branch.outputs.branch }}"
 
       - name: Add, commit and push changes to dist/generateContents.js
         if: steps.extract-branch.outputs.branch != 'main'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         id: set-sha
-        uses: nrwl/nx-set-shas@v2
+        uses: nrwl/nx-set-shas@v3
 
       - name: Install GraphicsMagick
         run: sudo apt-get update && sudo apt-get install -y ghostscript graphicsmagick


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Reference related issues using keywords supported by Github as described [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

Example:
Fixes #(issue number)
-->

`set-output` is being deprecated in GitHub actions, this PR replaces `set-output` with the recommendation from [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
I tested the output using the following command to verify the result was the same:
```yaml
      - name: Print prior output
        run: echo "${{ steps.extract-branch.outputs.branch }}"
```
And it printed `"refs/pull/179/merge"`.

I also updated `nrwl/nx-set-shas@v2` to `v3` as `v2` still used `set-output` and as a result, we received the warnings after the workflow ran.
Warnings shown in the following screenshot:
<img width="869" alt="image" src="https://user-images.githubusercontent.com/21305201/202202962-05e763e4-fd8d-43b7-9484-cdb554fbcec3.png">

## Type of change

<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
