### PR TITLE
ci: only run danger workflow on PRs

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -94,6 +94,7 @@ jobs:
           retention-days: 2
 
       - name: Danger
+        if: steps.extract-branch.outputs.branch != 'main'
         run: npx danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -28,9 +28,9 @@ function warnAndGenerateMarkdown(warning: string, markdownStr: string): void {
 }
 
 async function splitBigPR() {
-  const linesCount = await danger.git.linesOfCode('**/*');
+  const linesCount = (await danger.git.linesOfCode('**/*')) || 0;
   // exclude fixtures and auto generated files
-  const excludeLinesCount = await danger.git.linesOfCode(LINES_TO_EXCLUDE_FROM_COUNT_GLOB);
+  const excludeLinesCount = (await danger.git.linesOfCode(LINES_TO_EXCLUDE_FROM_COUNT_GLOB)) || 0;
   const totalLinesCount = linesCount - excludeLinesCount;
 
   if (totalLinesCount > BIG_PR_LIMIT) {
@@ -69,6 +69,7 @@ function positiveFeedback() {
 
 function checkCheckboxesAreTicked() {
   const prDescriptionChecklist = danger.github.pr.body?.split('## Checklist:')[1];
+  if (!prDescriptionChecklist) return;
   const emptyCheckboxes = prDescriptionChecklist.match(/\[ \]/g)?.length || 0;
   const tickedCheckboxes = prDescriptionChecklist.match(/\[x\]/g)?.length || 0;
 


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Reference related issues using keywords supported by Github as described [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

Example:
Fixes #(issue number)
-->

With the previous PR - https://github.com/s1seven/schema-tools/pull/186, we introduced danger.js to automate some parts of code reviews.
It works as expected, but when merging to main it also runs and throws a type error as the `danger.git` object is not populated (it is only populated for PRs).
This PR fixes the failing CI on merge to main by adding a condition that it only run when branch `!= main`.
It also adds some extra protections to `dangerfile.ts`.

## Type of change

<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
