### PR TITLE
ci: extract branch name before danger workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -93,16 +93,16 @@ jobs:
           path: ./coverage
           retention-days: 2
 
+      - name: Extract branch name
+        id: extract-branch
+        shell: bash
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+
       - name: Danger
         if: steps.extract-branch.outputs.branch != 'main'
         run: npx danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract branch name
-        id: extract-branch
-        shell: bash
-        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
       - name: Add, commit and push changes to dist/generateContents.js
         if: steps.extract-branch.outputs.branch != 'main'


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Reference related issues using keywords supported by Github as described [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

Example:
Fixes #(issue number)
-->

The danger workflow needs access to the branch name.
This PR moves the workflow that gets the branch name to before the danger workflow.

## Type of change

<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
