### PR TITLE
fix: update tag syntax for compatability with jscutlery/semver:version 

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@main
       - name: Run GitHub File Sync
-        uses: Redocly/repo-file-sync-action@master
+        uses: Redocly/repo-file-sync-action@main
         with:
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/packages/certificate-model/project.json
+++ b/packages/certificate-model/project.json
@@ -73,7 +73,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["certificate-model:release", "certificate-model:publish"]

--- a/packages/certificate-summary/project.json
+++ b/packages/certificate-summary/project.json
@@ -73,7 +73,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["certificate-summary:release", "certificate-summary:publish"]

--- a/packages/extract-emails/project.json
+++ b/packages/extract-emails/project.json
@@ -73,7 +73,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["extract-emails:release", "extract-emails:publish"]

--- a/packages/generate-coa-pdf-template/project.json
+++ b/packages/generate-coa-pdf-template/project.json
@@ -81,7 +81,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "push": true,
         "postTargets": ["generate-coa-pdf-template:release"]
       }

--- a/packages/generate-en10168-pdf-template/project.json
+++ b/packages/generate-en10168-pdf-template/project.json
@@ -82,7 +82,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "push": true,
         "postTargets": ["generate-en10168-pdf-template:release"]
       }

--- a/packages/generate-html/project.json
+++ b/packages/generate-html/project.json
@@ -80,7 +80,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["generate-html:release", "generate-html:publish"]

--- a/packages/generate-interfaces/project.json
+++ b/packages/generate-interfaces/project.json
@@ -66,7 +66,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["generate-interfaces:release", "generate-interfaces:publish"]

--- a/packages/generate-pdf-template-helpers/project.json
+++ b/packages/generate-pdf-template-helpers/project.json
@@ -66,7 +66,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["generate-pdf-template-helpers:release"]

--- a/packages/generate-pdf/project.json
+++ b/packages/generate-pdf/project.json
@@ -86,7 +86,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["generate-pdf:release", "generate-pdf:publish"]

--- a/packages/types/project.json
+++ b/packages/types/project.json
@@ -40,7 +40,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["types:release", "types:publish"]

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -73,7 +73,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["utils:release", "utils:publish"]

--- a/packages/validate/project.json
+++ b/packages/validate/project.json
@@ -73,7 +73,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["validate:release", "validate:publish"]

--- a/packages/versioning/project.json
+++ b/packages/versioning/project.json
@@ -66,7 +66,7 @@
         "preset": "conventional",
         "skipCommitTypes": ["docs", "ci"],
         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
-        "tagPrefix": "@s1seven/schema-tools-${projectName}@",
+        "tagPrefix": "@s1seven/schema-tools-{projectName}@",
         "trackDeps": true,
         "push": true,
         "postTargets": ["versioning:release", "versioning:publish"]


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Reference related issues using keywords supported by Github as described [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)

Example:
Fixes #(issue number)
-->

Version 4.0 of @jscutlery/semver updated the syntax from `${var}` to `{var}` - [https://github.com/jscutlery/semver/blob/main/packages/semver/CHANGELOG.md (und)](https://github.com/jscutlery/semver/blob/main/packages/semver/CHANGELOG.md#330-2023-10-07)
This PR updates the syntax in our project.json files to make it compatible, fixing a bug where the release version number was being set to 0.0.1.
Also updates `Redocly/repo-file-sync-action` to use `main` instead of `master` as described [here](https://github.com/Redocly/repo-file-sync-action/commit/77ac3fb3f0dbd4236d79995f2a52c0fe5612938a)

## Type of change

<!--
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] Dependencies update
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
